### PR TITLE
Fix p.py halvesAreAlike typo

### DIFF
--- a/p.py
+++ b/p.py
@@ -1,4 +1,4 @@
 class Solution:
     def halvesAreAlike(self, s: str) -> bool:
-        v = ('a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U')
-        return sum(ss in v for ss in s[:len(s)//2]) == sum(ss in v for ss in s[len(s)2:])
+        vowels = ('a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U')
+        return sum(ch in vowels for ch in s[:len(s)//2]) == sum(ch in vowels for ch in s[len(s)//2:])


### PR DESCRIPTION
## Summary
- fix bug in halvesAreAlike

## Testing
- `python3 -c "import p, sys; print(p.Solution().halvesAreAlike('book'))"`

------
https://chatgpt.com/codex/tasks/task_e_68731feacc3c83298f22c8ea8ec07e02

## Summary by Sourcery

Fix the bug in halvesAreAlike by correcting the slice for the second half of the string and renaming the vowel list variable for clarity

Bug Fixes:
- Correct the slice expression for the second half in halvesAreAlike

Enhancements:
- Rename variable `v` to `vowels` for improved readability